### PR TITLE
Removal of .status for redirect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ exports.register = function error_handler (server, options, next) {
       // custom redirect https://github.com/dwyl/hapi-error/issues/5
       if(options && options[statusCode] && options[statusCode].redirect) {
         return reply.redirect(options[statusCode].redirect
-          + '?redirect=' + request.url.path).code(statusCode);
+          + '?redirect=' + request.url.path);
       }
       else if (accept && accept.match(/json/)) { // support REST/JSON requests
         return reply(req.output.payload).code(statusCode);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,7 @@ test("GET /admin?hello=world should re-direct to /login?redirect=/admin?hello=wo
   };
   redirectserver.inject(options, function(res){
     // console.log(res);
-    t.equal(res.statusCode, 401, 'statusCode: + ' + res.statusCode + ' (as expected)');
+    t.equal(res.statusCode, 302, 'statusCode: + ' + res.statusCode + ' (as expected)');
     var url = '/login?redirect=/admin?hello=world';
     t.equal(res.headers.location, url, 'Successfully redirected to: ' + url);
     t.end(  redirectserver.stop(function(){ }) );


### PR DESCRIPTION
If the user is using the redirect option, the statusCode is already assumed and is not needed.

This would close #13 if agreed upon.
