### PR TITLE
"Accept" Header Priority

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,13 +10,14 @@ exports.register = function error_handler (server, options, next) {
       var accept = request.raw.req.headers.accept;
       var statusCode = req.output.payload.statusCode;
 
+      //Header check, should take priority
+      if (accept && accept.match(/json/)) { // support REST/JSON requests
+        return reply(req.output.payload).code(statusCode);
+      }
       // custom redirect https://github.com/dwyl/hapi-error/issues/5
-      if(options && options[statusCode] && options[statusCode].redirect) {
+      else if(options && options[statusCode] && options[statusCode].redirect) {
         return reply.redirect(options[statusCode].redirect
           + '?redirect=' + request.url.path);
-      }
-      else if (accept && accept.match(/json/)) { // support REST/JSON requests
-        return reply(req.output.payload).code(statusCode);
       }
       else { // this is the default error message:
         var msg = 'Sorry, something went wrong, please retrace your steps.';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-error",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "catch errors in your hapi application and display the appropriate error message/page",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This gives priority to the "Accept" header for API calls (POST, PUT) for more of an API-use-case as opposed to redirecting designated Boom requests to another page (web application routes).

Solves #17 
