### PR TITLE
Pass Hoek error object to Handlebars template for display on error page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "4.4.0"
+  - "4"
+  - "6"
 sudo: false
 after_success:
   - pip install --user codecov

--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ Output:
 
 <br />
 
+
+## Want to pass some more information/handlebar props to your error_template.html?
+
+All you have to do is pass an object to Hoek with an errorMessage property and any other handlebar properties you want!
+
+For example,
+```js
+Hoek.assert(!error, {errorMessage: 'Oops - there has been an error', email: 'example@example.example', colour:'blue'});
+```
+You will then be able to use {{email}} and {{colour}} in your error_template.html
+
 ## *Redirecting* to another endpoint
 
 Sometimes you don't _want_ to show an error page;

--- a/example/error_template.html
+++ b/example/error_template.html
@@ -32,6 +32,7 @@
       <h2 class='emoji'>&#x25D5; &#xFE35; &#x25D5;</h2>
       <h2>{{errorMessage}}</h2>
       <h1>{{statusCode}}</h1>
+      <p>{{email}}</p>
     </div>
 </body>
 </html>

--- a/example/server.js
+++ b/example/server.js
@@ -35,16 +35,16 @@ server.route([
     }
   },
   {
-  method: 'GET',
-  path: '/hoek-object',
-  config: {
-    handler: function (request, reply) {
-      var err = true; // force error using hoek
-      return Hoek.assert(!err, {email: 'test@test.test', errorMessage: 'Oops - there has been an error'});
-      // no reply because Hoek fires an error!
+    method: 'GET',
+    path: '/hoek-object',
+    config: {
+      handler: function (request, reply) {
+        var err = true; // force error using hoek
+        return Hoek.assert(!err, {email: 'test@test.test', errorMessage: 'Oops - there has been an error'});
+        // no reply because Hoek fires an error!
+      }
     }
-  }
-},
+  },
   {
     method: 'GET',
     path: '/register/{param*}',

--- a/example/server.js
+++ b/example/server.js
@@ -46,6 +46,17 @@ server.route([
     }
   },
   {
+  method: 'GET',
+  path: '/hoek-object',
+  config: {
+    handler: function (request, reply) {
+      var err = true; // force error using hoek
+      return Hoek.assert(!err, {email: 'test@test.test', errorMessage: 'Oops - there has been an error'});
+      // no reply because Hoek fires an error!
+    }
+  }
+},
+  {
     method: 'GET',
     path: '/register/{param*}',
     config: {

--- a/example/server.js
+++ b/example/server.js
@@ -35,17 +35,6 @@ server.route([
     }
   },
   {
-    method: 'GET',
-    path: '/hoek',
-    config: {
-      handler: function (request, reply) {
-        var err = true; // force error using hoek
-        return Hoek.assert(!err, 'Boom Goes the Dynamite!');
-        // no reply because Hoek fires an error!
-      }
-    }
-  },
-  {
   method: 'GET',
   path: '/hoek-object',
   config: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,18 +38,38 @@ exports.register = function error_handler (server, options, next) {
           default:
             break;
         }
-        // console.log(statusCode, req.output.payload);
-        return reply.view('error_template', {
-          errorTitle: req.output.payload.error,
-          statusCode: statusCode,
-          errorMessage: msg,
-        }).code(statusCode); // e.g 401, 404 or 500 etc.
+
+        msg = tryJsonParse(msg);
+
+        if (msg.object) {
+            return reply.view('error_template', Object.assign(msg.object, {
+                errorTitle: req.output.payload.error,
+                statusCode: statusCode
+            })).code(statusCode);
+        } else {
+            return reply.view('error_template', {
+                errorTitle: req.output.payload.error,
+                statusCode: statusCode,
+                errorMessage: msg,
+            }).code(statusCode); // e.g 401, 404 or 500 etc.
+        }
       }
     }
     reply.continue();
   });
   next(); // continue with other plugins
 };
+
+function tryJsonParse(str) {
+  try {
+      JSON.parse(str);
+  } catch (e) {
+      return str;
+  }
+  return {
+      object: JSON.parse(str)
+  };
+}
 
 exports.register.attributes = {
   pkg: require('../package.json')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-error",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "catch errors in your hapi application and display the appropriate error message/page",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,17 +31,17 @@
   "homepage": "https://github.com/dwyl/hapi-error#readme",
   "dependencies": {},
   "devDependencies": {
-    "boom": "^3.2.2",
+    "boom": "^4.0.0",
     "decache": "^4.1.0",
     "handlebars": "^4.0.5",
-    "hapi": "^14.2.0",
+    "hapi": "^15.0.2",
     "hoek": "^4.0.2",
-    "istanbul": "^0.4.2",
+    "istanbul": "^0.4.5",
     "joi": "^9.0.4",
-    "nodemon": "^1.9.1",
-    "pre-commit": "^1.1.2",
+    "nodemon": "^1.10.2",
+    "pre-commit": "^1.1.3",
     "tap-spec": "^4.1.1",
-    "tape": "^4.4.0",
+    "tape": "^4.6.0",
     "vision": "^4.1.0"
   },
   "pre-commit": [

--- a/test/error_object_server_example.js
+++ b/test/error_object_server_example.js
@@ -1,0 +1,21 @@
+require('decache')('../example/server.js'); // ensure we have a fresh module
+var server = require('../example/server.js');
+var Hoek   = require('hoek');
+
+server.register(
+  [
+    require('../lib/index.js'),
+    require('vision')
+  ],
+  function (err) {
+  Hoek.assert(!err, 'no errors registering plugins');
+});
+
+server.views({
+  engines: {
+    html: require('handlebars')
+  },
+  path: require('path').resolve(__dirname, '../example')
+});
+
+module.exports = server;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,6 +20,25 @@ test("GET /admin?hello=world should re-direct to /login?redirect=/admin?hello=wo
   });
 });
 
+/************************* ERROR OBJECT TEST ***************************/
+
+test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
+  require('decache')('../lib/index.js'); // ensure we have a fresh module
+  var errorObjectServer = require('./error_object_server_example');
+
+  var options = {
+    method: 'GET',
+    url: '/hoek-object'
+  };
+  errorObjectServer.inject(options, function(res){
+    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
+    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
+    t.equal(res.statusCode, 500, 'statusCode 500');
+    t.end(errorObjectServer.stop(function(){ }) );
+  });
+});
+
+
 /************************* Regular TESTS ***************************/
 
 test("GET / returns 200", function (t) {
@@ -138,20 +157,6 @@ test("GET /register/myscript fails additional (CUSTOM) validation", function (t)
   });
 });
 
-test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
-  var errorObjectServer = require('./error_object_server_example');
-
-  var options = {
-    method: 'GET',
-    url: '/hoek-object'
-  };
-  errorObjectServer.inject(options, function(res){
-    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
-    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
-    t.equal(res.statusCode, 500, 'statusCode 500');
-    t.end();
-  });
-});
 
 test("GET /hoek returns 'Boom Goes the Dynamite!'", function (t) {
   var options = {
@@ -167,5 +172,6 @@ test("GET /hoek returns 'Boom Goes the Dynamite!'", function (t) {
 
 
 test.onFinish(function () {
-  server.stop(function(){ }); // stop the hapi server after 500 error
+  process.exit();
+  server.stop(function(){}); // stop the hapi server after 500 error
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -138,6 +138,21 @@ test("GET /register/myscript fails additional (CUSTOM) validation", function (t)
   });
 });
 
+test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
+  var errorObjectServer = require('./error_object_server_example');
+
+  var options = {
+    method: 'GET',
+    url: '/hoek-object'
+  };
+  errorObjectServer.inject(options, function(res){
+    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
+    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
+    t.equal(res.statusCode, 500, 'statusCode 500');
+    t.end();
+  });
+});
+
 test("GET /hoek returns 'Boom Goes the Dynamite!'", function (t) {
   var options = {
     method: 'GET',
@@ -149,20 +164,6 @@ test("GET /hoek returns 'Boom Goes the Dynamite!'", function (t) {
     t.end();
   });
 });
-
-test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
-  var options = {
-    method: 'GET',
-    url: '/hoek-object'
-  };
-  server.inject(options, function(res){
-    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
-    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
-    t.equal(res.statusCode, 500, 'statusCode 500');
-    t.end();
-  });
-});
-
 
 
 test.onFinish(function () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -150,6 +150,20 @@ test("GET /hoek returns 'Boom Goes the Dynamite!'", function (t) {
   });
 });
 
+test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
+  var options = {
+    method: 'GET',
+    url: '/hoek-object'
+  };
+  server.inject(options, function(res){
+    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
+    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
+    t.equal(res.statusCode, 500, 'statusCode 500');
+    t.end();
+  });
+});
+
+
 
 test.onFinish(function () {
   server.stop(function(){ }); // stop the hapi server after 500 error

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,24 +20,6 @@ test("GET /admin?hello=world should re-direct to /login?redirect=/admin?hello=wo
   });
 });
 
-/************************* ERROR OBJECT TEST ***************************/
-
-test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
-  require('decache')('../lib/index.js'); // ensure we have a fresh module
-  var errorObjectServer = require('./error_object_server_example');
-
-  var options = {
-    method: 'GET',
-    url: '/hoek-object'
-  };
-  errorObjectServer.inject(options, function(res){
-    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
-    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
-    t.equal(res.statusCode, 500, 'statusCode 500');
-    t.end(errorObjectServer.stop(function(){ }) );
-  });
-});
-
 
 /************************* Regular TESTS ***************************/
 
@@ -157,21 +139,24 @@ test("GET /register/myscript fails additional (CUSTOM) validation", function (t)
   });
 });
 
+/************************* ERROR OBJECT TEST ***************************/
 
-test("GET /hoek returns 'Boom Goes the Dynamite!'", function (t) {
+test("GET /hoek-object returns message and extra email handlebar prop", function (t) {
+  require('decache')('../lib/index.js'); // ensure we have a fresh module
+  var errorObjectServer = require('./error_object_server_example');
+
   var options = {
     method: 'GET',
-    url: '/hoek'
+    url: '/hoek-object'
   };
-  server.inject(options, function(res){
-    t.ok(res.payload.includes('Boom Goes the Dynamite!'), 'Custom Error Messages!');
+  errorObjectServer.inject(options, function(res){
+    t.ok(res.payload.includes('Oops - there has been an error'), 'Correct Custom Error Messages!');
+    t.ok(res.payload.includes('test@test.test', 'Extra email handlebar prop displayed'));
     t.equal(res.statusCode, 500, 'statusCode 500');
-    t.end();
+    t.end(errorObjectServer.stop(function(){ }) );
   });
 });
 
-
 test.onFinish(function () {
-  process.exit();
-  server.stop(function(){}); // stop the hapi server after 500 error
+  server.stop(function(){ }); // stop the hapi server after 500 error
 });


### PR DESCRIPTION
This Pull Request allows us to pass full objects into the `Hoek.assert` makes the properties of the error object available in the Handlebars (_or your choice of other view/template engine_) error page. see:   #19
