### PR TITLE
Expose handleError for use in non-request handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,25 @@ Output:
 
 <br />
 
+### Need to call `handleError` outside of the context of the `request` ?
+
+Sometimes we create handlers that perform a task outside of the context of 
+a route/handler (_e.g accessing a database or API_) in this context 
+we still want to use `handleError` to simplify error handling.
+
+This is easy with `hapi-error`, here's an example:
+
+```js
+var handleError = require('hapi-error').handleError;
+
+db.get(key, function (error, result) {
+  handleError(error, 'Error retrieving ' + key + ' from DB :-( ');
+  callback(err, result);
+}); 
+
+
+```
+
 
 ### Want to pass some more/custom data your error_template.html?
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,8 @@ function handleError (error, errorMessage) {
 
   return Hoek.assert(!error, error);
 }
+// export for use in files that do not have access to the request object
+exports.handleError = handleError; // e.g. database-specific getters/setters
 
 /**
  * register defines our errorHandler plugin following the standard hapi plugin

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-error",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "catch errors in your hapi application and display the appropriate error message/page",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handleError.test.js
+++ b/test/handleError.test.js
@@ -1,0 +1,9 @@
+var test = require('tape');
+var handleError = require('../lib').handleError;
+
+test("handleError no error is thrown when error = null", function (t) {
+	var error = null;
+	t.equal(handleError(error), undefined, 'No error thrown');
+	t.end();
+});
+

--- a/test/handleError.test.js
+++ b/test/handleError.test.js
@@ -1,9 +1,0 @@
-var test = require('tape');
-var handleError = require('../lib').handleError;
-
-test("handleError no error is thrown when error = null", function (t) {
-	var error = null;
-	t.equal(handleError(error), undefined, 'No error thrown');
-	t.end();
-});
-

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,16 @@
 var test = require('tape');
 var server = require('../example/server_example');
 
+/************************* handleError method test ***************************/
+
+var handleError = require('../lib').handleError;
+
+test("handleError no error is thrown when error = null", function (t) {
+  var error = null;
+  t.equal(handleError(error), undefined, 'No error thrown');
+  t.end();
+});
+
 /************************* REDIRECT TEST ***************************/
 test("GET /admin?hello=world should re-direct to /login?redirect=/admin?hello=world", function (t) {
 


### PR DESCRIPTION
@iteles tiny PR to make `handleError` available in non-route handlers. 
