### PR TITLE
Message parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,23 +130,23 @@ Your `error_template.html` (*or `error_template.ext` `error_template.tag` `error
 
 ### 4. *Optional* Add config object to transform messages or redirect for certain status codes
 
-Each status code can be given two properties `messageTransform` and `redirect`.
+Each status code can be given two properties `message` and `redirect`.
 
 The default config is:
 ```
-var mergedConfig = {
-  401: { messageTransform: 'Please Login to view that page' },
-  400: { messageTransform: 'Sorry, we do not have that page.' },
-  404: { messageTransform: 'Sorry, that page is not available.' }
+{
+  401: { message: 'Please Login to view that page' },
+  400: { message: 'Sorry, we do not have that page.' },
+  404: { message: 'Sorry, that page is not available.' }
 };
 ```
 We want to provide useful error messages that are pleasant for the user. If you think there are better defaults for messages or other codes then do let us know via [issue](https://github.com/dwyl/hapi-error/issues).
 
 Any of the can be overwritten and new status codes can be added.
 
-#### `messageTransform` *Transform* the error message
+#### `message` Parse/replace the error message
 
-This parameter can the form `function(message, request)` or just simply a `'string'`.
+This parameter can be of the form `function(message, request)` or just simply a `'string'` to replace the message.
 
 An example of a use case would be handling errors form joi validation.
 
@@ -154,7 +154,7 @@ Or erroring in different languages.
 ```js
 const config = {
   "401": {
-    "transformMessage": function(msg, req) {
+    "message": function(msg, req) {
       var lang = findLang(req);
 
       return translate(lang, message);
@@ -162,6 +162,8 @@ const config = {
   }
 };
 ```
+
+Or providing nice error messages like in the default config above.
 
 #### `redirect` *Redirecting* to another endpoint
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,78 @@ Your `error_template.html` (*or `error_template.ext` `error_template.tag` `error
 
 > for an example see: [`/example/error_template.html`](https://github.com/dwyl/hapi-error/blob/master/example/error_template.html)
 
-*That's it*!
+### 4. *Optional* Add config object to transform messages or redirect for certain status codes
+
+Each status code can be given two properties `messageTransform` and `redirect`.
+
+The default config is:
+```
+var mergedConfig = {
+  401: { messageTransform: 'Please Login to view that page' },
+  400: { messageTransform: 'Sorry, we do not have that page.' },
+  404: { messageTransform: 'Sorry, that page is not available.' }
+};
+```
+We want to provide useful error messages that are pleasant for the user. If you think there are better defaults for messages or other codes then do let us know via [issue](https://github.com/dwyl/hapi-error/issues).
+
+Any of the can be overwritten and new status codes can be added.
+
+#### `messageTransform` *Transform* the error message
+
+This parameter can the form `function(message, request)` or just simply a `'string'`.
+
+An example of a use case would be handling errors form joi validation.
+
+Or erroring in different languages.
+```js
+const config = {
+  "401": {
+    "transformMessage": function(msg, req) {
+      var lang = findLang(req);
+
+      return translate(lang, message);
+    }
+  }
+};
+```
+
+#### `redirect` *Redirecting* to another endpoint
+
+Sometimes you don't _want_ to show an error page;
+_instead_ you want to re-direct to another page.
+For example, when your route/page requires the person
+to be authenticated (_logged in_), but they have
+not supplied a valid session/token to view the route/page.
+
+In this situation the default Hapi behaviour is to return a `401` (_unauthorized_) error,
+however this is not very _useful_ to the _person_ using your application.
+
+Redirecting to a specific url is _easy_ with `hapi-error`:
+
+```js
+const config = {
+	"401": { // if the statusCode is 401 redirect to /login page/endpoint
+		"redirect": "/login"
+	}
+}
+server.register([{
+    register: require('hapi-error'),
+    options: config // pass in your redirect configuration in options
+  },
+  require('vision')], function (err) {
+    // etc.
+});  
+```
+
+This will `redirect` the client/browser to the `/login` endpoint
+and will append a query parameter with the url the person was _trying_ to visit.
+
+e.g: GET /admin --> 401 unauthorized --> redirect to /login?redirect=/admin
+
+> Redirect Example: [/redirect_server_example.js](https://github.com/dwyl/hapi-error/blob/master/test/redirect_server_example.js)
+
+
+## *That's it*!
 
 *Want more...?* [*ask*!](https://github.com/dwyl/hapi-error/issues)
 
@@ -224,42 +295,7 @@ For example:
 request.handleError(!error, {errorMessage: 'Oops - there has been an error',
 email: 'example@mail.co', color:'blue'});
 ```
-You will then be able to use {{email}} and {{colur}} in your `error_template.html`
-
-### *Redirecting* to another endpoint
-
-Sometimes you don't _want_ to show an error page;
-_instead_ you want to re-direct to another page.
-For example, when your route/page requires the person
-to be authenticated (_logged in_), but they have
-not supplied a valid session/token to view the route/page.
-
-In this situation the default Hapi behaviour is to return a `401` (_unauthorized_) error,
-however this is not very _useful_ to the _person_ using your application.
-
-Redirecting to a specific url is _easy_ with `hapi-error`:
-
-```js
-const redirectConfig = {
-	"401": { // if the statusCode is 401 redirect to /login page/endpoint
-		"redirect": "/login"
-	}
-}
-server.register([{
-    register: require('hapi-error'),
-    options: redirectConfig // pass in your redirect configuration in options
-  },
-  require('vision')], function (err) {
-    // etc.
-});  
-```
-
-This will `redirect` the client/browser to the `/login` endpoint
-and will append a query parameter with the url the person was _trying_ to visit.
-
-e.g: GET /admin --> 401 unauthorized --> redirect to /login?redirect=/admin
-
-> Redirect Example: [/redirect_server_example.js](https://github.com/dwyl/hapi-error/blob/master/test/redirect_server_example.js)
+You will then be able to use {{email}} and {{color}} in your `error_template.html`
 
 ### logging
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,9 +12,9 @@ var pkg = require('../package.json'); // require package.json for attributes
  */
 function createConfig (config) {
   var mergedConfig = {
-    401: { messageTransform: 'Please Login to view that page' },
-    400: { messageTransform: 'Sorry, we do not have that page.' },
-    404: { messageTransform: 'Sorry, that page is not available.' }
+    401: { message: 'Please Login to view that page' },
+    400: { message: 'Sorry, we do not have that page.' },
+    404: { message: 'Sorry, that page is not available.' }
   };
 
   Object.keys(config).forEach(function (statusCode) {
@@ -120,10 +120,10 @@ exports.register = function hapiError (server, options, next) {
           + '?redirect=' + request.url.path);
       }
 
-      if (config[statusCode] && config[statusCode].messageTransform) {
-        msg = typeof config[statusCode].messageTransform === 'function'
-          ? config[statusCode].messageTransform(msg, request)
-          : config[statusCode].messageTransform
+      if (config[statusCode] && config[statusCode].message) {
+        msg = typeof config[statusCode].message === 'function'
+          ? config[statusCode].message(msg, request)
+          : config[statusCode].message
         ;
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,46 @@ var Hoek = require('hoek');
 var pkg = require('../package.json'); // require package.json for attributes
 
 /**
+ * Takes a value and checks to see if object, i.e. not array or null.
+ * @param {*} value - the value you are trying to test
+ * @returns {Boolean} true if simple object false if other type or array or null
+ */
+function isObject (value) {
+  return typeof value === 'object' && !Array.isArray(value) && value !== null;
+}
+
+/**
+ * Merges in custom options to teh default config for each status code
+ * @param {Object} config - the custom option object with status codes as keys
+ * and objects with settings as values
+ * @returns {Object} config to be used in plugin with defaults overwritten
+ * and or added to
+ */
+function createConfig (config) {
+  var mergedConfig = {
+    401: { messageTransform: 'Please Login to view that page' },
+    400: { messageTransform: 'Sorry, we do not have that page.' },
+    404: { messageTransform: 'Sorry, that page is not available.' }
+  };
+
+  if (!isObject(config)) {
+    return mergedConfig;
+  }
+
+  Object.keys(config).forEach(function (statusCode) {
+    if (!mergedConfig[statusCode]) {
+      mergedConfig[statusCode] = {};
+    }
+
+    Object.keys(config[statusCode]).forEach(function (setting) {
+      mergedConfig[statusCode][setting] = config[statusCode][setting];
+    });
+  });
+
+  return mergedConfig;
+}
+
+/**
  * Takes a string and attempts to parse it as a JSON Object.
  * @param {String} str - a string which *may* be a JSON.stringified Object
  * @returns {Object|String} in the case where the str was a Stringified Object
@@ -44,6 +84,9 @@ exports.handleError = handleError; // e.g. database-specific getters/setters
  * @returns {Function} reply.continue is called when the plugin is finished
  */
 exports.register = function hapiError (server, options, next) {
+  // creates config for handler to be used in 'onPreResponse' function
+  var config = createConfig(options);
+
   // make handleError available on request
   server.ext('onRequest', function (request, reply) {
     request.handleError = handleError; // github.com/dwyl/hapi-error/issues/23
@@ -85,23 +128,16 @@ exports.register = function hapiError (server, options, next) {
         return reply(res.output.payload).code(statusCode);
       }
       // custom redirect https://github.com/dwyl/hapi-error/issues/5
-      if (options && options[statusCode] && options[statusCode].redirect) {
-        return reply.redirect(options[statusCode].redirect
+      if (config[statusCode] && config[statusCode].redirect) {
+        return reply.redirect(config[statusCode].redirect
           + '?redirect=' + request.url.path);
       }
-      switch (statusCode) {
-      case 404:
-        msg = 'Sorry, that page is not available.';
-        break;
-      case 401:
-        msg = 'Please Login to view that page';
-        break;
-      case 400:
-        // statusCode = 404; // over-ride error code?
-        msg = 'Sorry, we do not have that page.';
-        break;
-      default:
-        break;
+
+      if (config[statusCode] && config[statusCode].messageTransform) {
+        msg = typeof config[statusCode].messageTransform === 'function'
+          ? config[statusCode].messageTransform(msg, request)
+          : config[statusCode].messageTransform
+        ;
       }
 
       msg = tryJsonParse(msg);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,15 +4,6 @@ var Hoek = require('hoek');
 var pkg = require('../package.json'); // require package.json for attributes
 
 /**
- * Takes a value and checks to see if object, i.e. not array or null.
- * @param {*} value - the value you are trying to test
- * @returns {Boolean} true if simple object false if other type or array or null
- */
-function isObject (value) {
-  return typeof value === 'object' && !Array.isArray(value) && value !== null;
-}
-
-/**
  * Merges in custom options to teh default config for each status code
  * @param {Object} config - the custom option object with status codes as keys
  * and objects with settings as values
@@ -25,10 +16,6 @@ function createConfig (config) {
     400: { messageTransform: 'Sorry, we do not have that page.' },
     404: { messageTransform: 'Sorry, that page is not available.' }
   };
-
-  if (!isObject(config)) {
-    return mergedConfig;
-  }
 
   Object.keys(config).forEach(function (statusCode) {
     if (!mergedConfig[statusCode]) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "nocov": "./node_modules/tape/bin/tape ./test/*.test.js",
     "dev": "PORT=8000 ./node_modules/.bin/nodemon example/server_example.js",
     "start": "node example/server_example.js",
-    "check-coverage": "npm run coverage && node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
+    "check-coverage": "npm run test && node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "lint": "node_modules/.bin/goodparts ./lib"
   },
   "repository": {
@@ -44,7 +44,7 @@
   },
   "pre-commit": [
     "lint",
-    "test"
+    "check-coverage"
   ],
   "keywords": [
     "custom",

--- a/test/message_server_example.js
+++ b/test/message_server_example.js
@@ -9,12 +9,12 @@ var HapiError = require('../lib/index.js');
 
 var config = {
   404: { // if the statusCode is 401 redirect to /login page/endpoint
-    messageTransform: function () {
+    message: function () {
       return 'robots in disguise';
     }
   },
   500: {
-    messageTransform: function (msg, request) {
+    message: function (msg, request) {
       return 'User agent: ' + request.headers['user-agent'];
     }
   }

--- a/test/message_server_example.js
+++ b/test/message_server_example.js
@@ -1,0 +1,35 @@
+require('decache')('../example/server.js');
+// ensure we have a fresh module
+var server = require('../example/server.js');
+var Hoek = require('hoek');
+var Vision = require('vision');
+var Path = require('path');
+var Handlebars = require('handlebars');
+var HapiError = require('../lib/index.js');
+
+var config = {
+  404: { // if the statusCode is 401 redirect to /login page/endpoint
+    messageTransform: function () {
+      return 'robots in disguise';
+    }
+  },
+  500: {
+    messageTransform: function (msg, request) {
+      return 'User agent: ' + request.headers['user-agent'];
+    }
+  }
+};
+
+server.register([
+  { register: HapiError, options: config },
+  Vision
+], function (err) {
+  Hoek.assert(!err, 'no errors registering plugins');
+});
+
+server.views({
+  engines: { html: Handlebars },
+  path: Path.resolve(__dirname, '../example')
+});
+
+module.exports = server;

--- a/test/redirect_server_example.js
+++ b/test/redirect_server_example.js
@@ -2,7 +2,7 @@ require('decache')('../example/server.js'); // ensure we have a fresh module
 var server = require('../example/server.js');
 var Hoek = require('hoek');
 
-var redirectConfig = {
+var config = {
 	"401": { // if the statusCode is 401 redirect to /login page/endpoint
 		"redirect": "/login"
 	}
@@ -10,7 +10,7 @@ var redirectConfig = {
 
 server.register([{
     register: require('../lib/index.js'),
-    options: redirectConfig // pass in your redirect configuration in options
+    options: config // pass in your redirect configuration in options
   },
   require('vision')], function (err) {
   Hoek.assert(!err, 'no errors registering plugins');
@@ -20,7 +20,7 @@ server.views({
   engines: {
     html: require('handlebars')
   },
-  path: require('path').resolve(__dirname, './')
+  path: require('path').resolve(__dirname, '../example')
 });
 
 module.exports = server;


### PR DESCRIPTION
Addresses discussion in #31 

Backward compatible, i.e. should behave the same as before for other users as same defaults are used.

But added ability to customise plugin and transform error messages.

Let me know if you approve and I can republish bump up the version accordingly.
