### PR TITLE
Make error message param optional

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function tryJsonParse (str) {
 /**
  * Takes an error Object and Message and throws Hoek Error if not null
  * @param {String} error - error Object or null
- * @param {String|Object=} errorMessage - Optional error message String or Object
+ * @param {String|Object} [errorMessage] - Optional error message String or Object
  * @returns {Boolean} false.
  */
 function handleError (error, errorMessage) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function tryJsonParse (str) {
 /**
  * Takes an error Object and Message and throws Hoek Error if not null
  * @param {String} error - error Object or null
- * @param {String|Object} errorMessage - Optional error message String or Object
+ * @param {String|Object=} errorMessage - Optional error message String or Object
  * @returns {Boolean} false.
  */
 function handleError (error, errorMessage) {


### PR DESCRIPTION
Makes the errorMessage parameter for handleError method optional in the JS docs
