### PR TITLE
Allow Template Name Configuration.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,18 +12,26 @@ var pkg = require('../package.json'); // require package.json for attributes
  */
 function createConfig (config) {
   var mergedConfig = {
-    401: { message: 'Please Login to view that page' },
-    400: { message: 'Sorry, we do not have that page.' },
-    404: { message: 'Sorry, that page is not available.' }
+    statusCodes: {
+      401: { message: 'Please Login to view that page' },
+      400: { message: 'Sorry, we do not have that page.' },
+      404: { message: 'Sorry, that page is not available.' }
+    }
   };
 
-  Object.keys(config).forEach(function (statusCode) {
-    if (!mergedConfig[statusCode]) {
-      mergedConfig[statusCode] = {};
-    }
+  // Target status code configuration objects.
+  var statusCodes = config.statusCodes || config; // Backwards compatibility.
 
-    Object.keys(config[statusCode]).forEach(function (setting) {
-      mergedConfig[statusCode][setting] = config[statusCode][setting];
+  // Configure error template name.
+  mergedConfig.templateName = config.templateName || mergedConfig.templateName;
+
+  Object.keys(statusCodes).forEach(function (statusCode) {
+    if (!mergedConfig.statusCodes[statusCode]) {
+      mergedConfig.statusCodes[statusCode] = {};
+    }
+    // Configure status code settings.
+    Object.keys(statusCodes[statusCode]).forEach(function (setting) {
+      mergedConfig.statusCodes[statusCode][setting] = statusCodes[statusCode][setting];
     });
   });
 
@@ -115,15 +123,15 @@ exports.register = function hapiError (server, options, next) {
         return reply(res.output.payload).code(statusCode);
       }
       // custom redirect https://github.com/dwyl/hapi-error/issues/5
-      if (config[statusCode] && config[statusCode].redirect) {
-        return reply.redirect(config[statusCode].redirect
+      if (config.statusCodes[statusCode] && config.statusCodes[statusCode].redirect) {
+        return reply.redirect(config.statusCodes[statusCode].redirect
           + '?redirect=' + request.url.path);
       }
 
-      if (config[statusCode] && config[statusCode].message) {
-        msg = typeof config[statusCode].message === 'function'
-          ? config[statusCode].message(msg, request)
-          : config[statusCode].message
+      if (config.statusCodes[statusCode] && config.statusCodes[statusCode].message) {
+        msg = typeof config.statusCodes[statusCode].message === 'function'
+          ? config.statusCodes[statusCode].message(msg, request)
+          : config.statusCodes[statusCode].message
         ;
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,7 @@ var pkg = require('../package.json'); // require package.json for attributes
  */
 function createConfig (config) {
   var mergedConfig = {
+    templateName: 'error_template',
     statusCodes: {
       401: { message: 'Please Login to view that page' },
       400: { message: 'Sorry, we do not have that page.' },
@@ -138,13 +139,13 @@ exports.register = function hapiError (server, options, next) {
       msg = tryJsonParse(msg);
 
       if (msg.object) { // assiging the debug first lets dev override
-        return reply.view('error_template', Object.assign(debug, msg.object, {
+        return reply.view(config.templateName, Object.assign(debug, msg.object, {
           errorTitle: res.output.payload.error,
           statusCode: statusCode
         })).code(statusCode);
       }
 
-      return reply.view('error_template', Object.assign(debug, {
+      return reply.view(config.templateName, Object.assign(debug, {
         errorTitle: res.output.payload.error,
         statusCode: statusCode,
         errorMessage: msg


### PR DESCRIPTION
Hey! Cool plugin. I keep the views for my plugins under a folder called `/views` and felt like the file name suffix of `_template` was a bit redundant. It's already assumed to be a template since it's located within the `/views` directory. I'd rather call it `error`. This PR adds the ability to do that while maintaining backwards compatibility with the existing configuration options object.

For example, this will continue to work:

```js
const config = {
  '401': { 'redirect': '/login' }
};
```

.... but now you can do this too:

```js
const config = {
  templateName: 'error',
  '401': { 'redirect': '/login' }
};
```

...or this:

```js
const config = {
  templateName: 'error',
  statusCodes: {
    '401': { 'redirect': '/login' }
  }
};
```

Let me know what you think. The linter complained about a couple lines being too long and some existing issue that was already present related to a function's name. I didn't update the read me file. If you find this useful and are willing to accept the PR I can do that (tell me what you want), or feel free to merge and decide how to present these options yourself. 

All 27 tests are passing locally for me and coverage still seems on point:

![screen shot 2016-11-19 at 11 52 17 am](https://cloud.githubusercontent.com/assets/461249/20456925/a1d7e87c-ae4e-11e6-9c61-b972bac0f76b.png)
