### PR TITLE
add the stack trace to the logged error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -115,7 +115,8 @@ exports.register = function hapiError (server, options, next) {
         email: request.auth.credentials && request.auth.credentials.email
           ? request.auth.credentials.email : '', // see: https://git.io/vPZBK
         payload: request.payload, // the complete request payload received
-        response: res.output.payload // response before error intercepted
+        response: res.output.payload, // response before error intercepted
+        stack_trace: res.stack // the stack trace of the error
       };
       // ALWAYS Log the error
       server.log('error', debug); // see: github.com/dwyl/hapi-error/issues/22


### PR DESCRIPTION
resolves #43 

@nelsonic I couldn't see any real tests that are checking the server logging functionality. Not sure if I missed something?

Also I got the following error after committing:
![screen shot 2017-01-11 at 19 17 00](https://cloud.githubusercontent.com/assets/12638261/21862929/3f376288-d833-11e6-9109-7b87a032e341.png)

Which seems to point at the following line:

![screen shot 2017-01-11 at 19 17 21](https://cloud.githubusercontent.com/assets/12638261/21862933/430af230-d833-11e6-99b5-4e81932a38f1.png)

Which I can issue up if you want?
