### PR TITLE
Log original error for compatibility with good-squeeze

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -118,8 +118,9 @@ exports.register = function hapiError (server, options, next) {
         response: res.output.payload, // response before error intercepted
         stack_trace: res.stack // the stack trace of the error
       };
-      // ALWAYS Log the error
-      server.log('error', debug); // see: github.com/dwyl/hapi-error/issues/22
+
+      // Log the initial error to ensure error event type.
+      server.log('error', res); // see: github.com/dwyl/hapi-error/issues/22
 
       // Header check, should take priority
       if (accept && accept.match(/json/)) { // support REST/JSON requests


### PR DESCRIPTION
I've been struggling to get hapi-error working correctly with good and the event type filters with good-squeeze. 

The good config below works because we're filtering log messages with the tag 'error', and this works okay- but the stack traces are pretty difficult to read in development.

```
const goodOptions = {
  ops: { interval: 1000, },
  reporters: {
    myConsoleReporter: [{
      module: 'good-squeeze',
      name: 'Squeeze',
      args: [{ log: 'error', error: '*' }],
    }, {
      module: 'good-console',
    }, 'stdout'],
  }
};

```

Ideally I'd like to just capture error:'*' events and retain the original error object by using the good-squeeze filter below.

```
      args: [{  error: '*' }],
```

In this PR I just log the original boom object which seems to work well, this probably needs further consideration and possible a config option.. Please feel free to suggest changes, I just wanted to get a discussion going :)


Edit: -- Closing this as I've noticed this approach still requires the `log: 'error'` filter to work, the only difference is the stack trace is easier to read.. 

