### PR TITLE
Fix TypeScript namespace declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare namespace hapiError{
         statusCodes?: {};
     }
     type handleError = (error: Error, errorMessage: string) => boolean;
-};
+}
 
 
 declare const hapiError: Plugin<hapiError.Options>;


### PR DESCRIPTION
Remove a semicolon in the namespace declaration to fix the following TypeScript error:

```
Error at node_modules/hapi-error/index.d.ts:15:2: Statements are not allowed in ambient contexts.
```

Fixes #61.