### PR TITLE
Bugfix/redirect url

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,10 @@
 var Hoek = require('hoek');
 var pkg = require('../package.json'); // require package.json for attributes
 
+function isFunction(functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+}
+
 /**
  * Merges in custom options to teh default config for each status code
  * @param {Object} config - the custom option object with status codes as keys
@@ -106,24 +110,25 @@ exports.plugin = {
             return reply.response(res.output.payload).code(statusCode);
           }
           // custom redirect https://github.com/dwyl/hapi-error/issues/5
-          if (config.statusCodes[statusCode]
-            && config.statusCodes[statusCode].redirect) {
+          var currentCodeConfig = config.statusCodes[statusCode];
+          if (currentCodeConfig && currentCodeConfig.redirect) {
             // if parameter is function, process it and redirect exactly as given (unless false or null)
-            if (typeof config.statusCodes[statusCode].redirect === 'function') {
-              let redirectPath = config.statusCodes[statusCode].redirect(request);
+            if (isFunction(currentCodeConfig.redirect)) {
+              let redirectPath = currentCodeConfig.redirect(request);
               if (redirectPath) {
                 return reply.redirect(redirectPath);
               }
-            } else if (config.statusCodes[statusCode].redirect) { // if parameter is string, append redirect query
-              return reply.redirect(config.statusCodes[statusCode].redirect + '?redirect=' + request.url.path);
+            } else if (currentCodeConfig.redirect) { // if parameter is string, append redirect query
+              var redirectString = request.url.pathname + request.url.search;
+              return reply.redirect(currentCodeConfig.redirect + '?redirect=' + redirectString);
             }
           }
 
-          if (config.statusCodes[statusCode]
-            && config.statusCodes[statusCode].message) {
-            msg = typeof config.statusCodes[statusCode].message === 'function'
-              ? config.statusCodes[statusCode].message(msg, request)
-              : config.statusCodes[statusCode].message
+          if (currentCodeConfig
+            && currentCodeConfig.message) {
+            msg = isFunction(currentCodeConfig.message)
+              ? currentCodeConfig.message(msg, request)
+              : currentCodeConfig.message
             ;
           }
 


### PR DESCRIPTION
this PR is for https://github.com/dwyl/hapi-error/issues/69

-----------------------------------------------------------------------------

Hapi server used Node URL.

if we look at the old documentation ([v4](https://nodejs.org/docs/latest-v4.x/api/url.html)) we will see the **path** key

But in earlier versions of NodeJS ([v6](https://nodejs.org/docs/latest-v6.x/api/url.html)) - the key **path** is missing

I'll try something like this:
```
+ '?redirect=' + (request.url.pathname + request.url.search)
```

**search**: The 'query string' portion of the URL, including the leading question mark.
Example: '?query=string'
**pathname**: The path section of the URL, that comes after the host and before the query, including the initial slash if present. No decoding is performed.
Example: '/p/a/t/h'

These parameters are present in the old version of NodeJS
