### PR TITLE
Update Dependencies Issue #73

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ const config = {
     },
     "403": { // if the statusCode is 403
       "redirect": function (request) {
-        return "/login?redirect=" + request.url.path
+        return "/login?redirect=" + request.url.pathname
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -15,16 +15,6 @@ and send a *useful* message to the client.
 [![HitCount](http://hits.dwyl.io/dwyl/hapi-error.svg)](http://hits.dwyl.io/dwyl/hapi-error)
 [![npm package version](https://img.shields.io/npm/v/hapi-error.svg?style=flat-square)](https://www.npmjs.com/package/hapi-error)
 
-<!--
-[![Build Status](https://travis-ci.org/dwyl/hapi-error.svg?branch=master)](https://travis-ci.org/dwyl/hapi-error)
-[![Test Coverage](https://img.shields.io/codecov/c/github/dwyl/hapi-error.svg?maxAge=2592000)](https://codecov.io/github/dwyl/hapi-error?branch=master)
-[![JavaScript Style Guide](https://img.shields.io/badge/code%20style-goodparts-brightgreen.svg)](https://github.com/dwyl/goodparts)
-[![Code Climate](https://codeclimate.com/github/dwyl/hapi-error/badges/gpa.svg)](https://codeclimate.com/github/dwyl/hapi-error)
-[![Dependency Status](https://david-dm.org/dwyl/hapi-error.svg)](https://david-dm.org/dwyl/hapi-error)
-[![devDependencies Status](https://david-dm.org/dwyl/hapi-error/dev-status.svg)](https://david-dm.org/dwyl/hapi-error?type=dev)
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/hapi-error/issues)
-[![npm package version](https://img.shields.io/npm/v/hapi-error.svg)](https://www.npmjs.com/package/hapi-error)
--->
 
 ![dilbert-404-error](https://cloud.githubusercontent.com/assets/194400/17856406/53feeee4-6875-11e6-8480-d493906f6aa1.png)
 
@@ -465,6 +455,3 @@ If you have _any_ questions, just [*ask*!](https://github.com/dwyl/hapi-error/is
 
 + Writing *useful* / *friendly* error messages:
 https://medium.com/@thomasfuchs/how-to-write-an-error-message-883718173322
-
-[![https://nodei.co/npm/hapi-error.png?downloads=true&downloadRank=true&stars=true](https://nodei.co/npm/hapi-error.png?downloads=true&downloadRank=true&stars=true)](https://www.npmjs.com/package/hapi-error)
-[![HitCount](https://hitt.herokuapp.com/dwyl/hapi-error.svg)](https://github.com/dwyl/hapi-error)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 <div align="center">
+
 # `hapi-error`
 
 Intercept errors in your Hapi web app/api
 and send a *useful* message to the client.
+
+![dilbert-404-error](https://cloud.githubusercontent.com/assets/194400/17856406/53feeee4-6875-11e6-8480-d493906f6aa1.png)
 
 [![Known Vulnerabilities](https://snyk.io/test/github/dwyl/hapi-error/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/dwyl/hapi-error?targetFile=package.json)
 [![Build Status](https://img.shields.io/travis/dwyl/hapi-error/master.svg?style=flat-square)](https://travis-ci.org/dwyl/hapi-error)
@@ -15,8 +18,6 @@ and send a *useful* message to the client.
 [![HitCount](http://hits.dwyl.io/dwyl/hapi-error.svg)](http://hits.dwyl.io/dwyl/hapi-error)
 [![npm package version](https://img.shields.io/npm/v/hapi-error.svg?style=flat-square)](https://www.npmjs.com/package/hapi-error)
 
-
-![dilbert-404-error](https://cloud.githubusercontent.com/assets/194400/17856406/53feeee4-6875-11e6-8480-d493906f6aa1.png)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,21 @@
-# hapi-error
+<div align="center">
+# `hapi-error`
 
-Intercept errors in your Hapi web app/api and send a *useful* message to the client.
+Intercept errors in your Hapi web app/api
+and send a *useful* message to the client.
 
+[![Known Vulnerabilities](https://snyk.io/test/github/dwyl/hapi-error/badge.svg?targetFile=package.json&style=flat-square)](https://snyk.io/test/github/dwyl/hapi-error?targetFile=package.json)
+[![Build Status](https://img.shields.io/travis/dwyl/hapi-error/master.svg?style=flat-square)](https://travis-ci.org/dwyl/hapi-error)
+[![codecov.io](https://img.shields.io/codecov/c/github/dwyl/hapi-error/master.svg?style=flat-square)](http://codecov.io/github/dwyl/hapi-error?branch=master)
+[![HAPI 18.4.x](http://img.shields.io/badge/hapi-18.4.0-brightgreen.svg?style=flat-square "Latest Hapi.js")](http://hapijs.com)
+[![Node.js Version](https://img.shields.io/node/v/hapi-error.svg?style=flat-square "Node.js 10 & 12 and io.js latest both supported")](http://nodejs.org/download/)
+[![Dependencies Status](https://david-dm.org/dwyl/hapi-error/status.svg?style=flat-square)](https://david-dm.org/dwyl/hapi-error)
+[![devDependencies Status](https://david-dm.org/dwyl/hapi-error/dev-status.svg?style=flat-square)](https://david-dm.org/dwyl/hapi-error?type=dev)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/hapi-error/issues)
+[![HitCount](http://hits.dwyl.io/dwyl/hapi-error.svg)](http://hits.dwyl.io/dwyl/hapi-error)
+[![npm package version](https://img.shields.io/npm/v/hapi-error.svg?style=flat-square)](https://www.npmjs.com/package/hapi-error)
+
+<!--
 [![Build Status](https://travis-ci.org/dwyl/hapi-error.svg?branch=master)](https://travis-ci.org/dwyl/hapi-error)
 [![Test Coverage](https://img.shields.io/codecov/c/github/dwyl/hapi-error.svg?maxAge=2592000)](https://codecov.io/github/dwyl/hapi-error?branch=master)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-goodparts-brightgreen.svg)](https://github.com/dwyl/goodparts)
@@ -10,10 +24,11 @@ Intercept errors in your Hapi web app/api and send a *useful* message to the cli
 [![devDependencies Status](https://david-dm.org/dwyl/hapi-error/dev-status.svg)](https://david-dm.org/dwyl/hapi-error?type=dev)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/dwyl/hapi-error/issues)
 [![npm package version](https://img.shields.io/npm/v/hapi-error.svg)](https://www.npmjs.com/package/hapi-error)
-
+-->
 
 ![dilbert-404-error](https://cloud.githubusercontent.com/assets/194400/17856406/53feeee4-6875-11e6-8480-d493906f6aa1.png)
 
+</div>
 
 ## *Why*?
 
@@ -69,7 +84,7 @@ that in the `headers.accept` and it will still receive the JSON error messages.
 ## *v2.0.0 Changes*
 1. Support for Hapi.js v17
 2. Not backward compatible with Hapi.js < v17
-3. Requires NodeJS v8 and above 
+3. Requires NodeJS v8 and above
 
 ## *How*?
 
@@ -241,7 +256,7 @@ e.g: GET /admin --> 401 unauthorized --> redirect to /login?redirect=/admin
 
 > Redirect Example: [/redirect_server_example.js](https://github.com/dwyl/hapi-error/blob/master/test/redirect_server_example.js)
 
-  
+
 ## *That's it*!
 
 *Want more...?* [*ask*!](https://github.com/dwyl/hapi-error/issues)

--- a/example/server.js
+++ b/example/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Hapi = require('hapi');
-var Boom = require('boom');
+var Boom = require('@hapi/boom');
 var Hoek = require('@hapi/hoek');
 var Joi = require('joi');
 

--- a/example/server.js
+++ b/example/server.js
@@ -2,7 +2,7 @@
 
 var Hapi = require('hapi');
 var Boom = require('boom');
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 var Joi = require('joi');
 
 var server = new Hapi.Server({ port: process.env.PORT });

--- a/example/server.js
+++ b/example/server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Hapi = require('hapi');
-var Boom = require('@hapi/boom');
+var Boom = require('boom');
 var Hoek = require('@hapi/hoek');
 var Joi = require('joi');
 

--- a/example/server_example.js
+++ b/example/server_example.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var server = require('./server.js');
-var Hoek   = require('hoek');
+var Hoek   = require('@hapi/hoek');
 
 module.exports = async () => {
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ exports.plugin = {
             method: req.method, // e.g GET/POST
             url: request.url.path, // the path the person requested
             headers: request.raw.req.headers, // all HTTP Headers
-            info: request.info, // all additional request info (useful for debugging)
+            info: request.info, // all additional request info (useful to debug)
             auth: request.auth, // any authentication details e.g. decoded JWT
             payload: request.payload, // the complete request payload received
             response: res.output.payload, // response before error intercepted

--- a/lib/index.js
+++ b/lib/index.js
@@ -104,7 +104,7 @@ exports.plugin = {
             method: req.method, // e.g GET/POST
             url: request.url.path, // the path the person requested
             headers: request.raw.req.headers, // all HTTP Headers
-            info: request.info, // all additional request info (useful to debug)
+            info: request.info, // all additional request info (useful for debugging)
             auth: request.auth, // any authentication details e.g. decoded JWT
             payload: request.payload, // the complete request payload received
             response: res.output.payload, // response before error intercepted

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,16 @@
 var Hoek = require('@hapi/hoek');
 var pkg = require('../package.json'); // require package.json for attributes
 
+/**
+ * isFunction checks if a given value is a function.
+ * @param {Object} functionToCheck - the object we want to confirm is a function
+ * @returns {Boolean} true|false
+ */
 function isFunction(functionToCheck) {
-  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+  const toString = Object.prototype.toString;
+  return functionToCheck
+    && toString.call(functionToCheck) === '[object Function]'
+    || toString.call(functionToCheck) === '[object AsyncFunction]';
 }
 
 /**
@@ -96,14 +104,14 @@ exports.plugin = {
             method: req.method, // e.g GET/POST
             url: request.url.path, // the path the person requested
             headers: request.raw.req.headers, // all HTTP Headers
-            info: request.info, // all additional request info (useful for debug)
-            auth: request.auth, // any authentication details e.g. the decoded JWT
+            info: request.info, // all additional request info (useful to debug)
+            auth: request.auth, // any authentication details e.g. decoded JWT
             payload: request.payload, // the complete request payload received
             response: res.output.payload, // response before error intercepted
             stackTrace: res.stack // the stack trace of the error
           };
           // ALWAYS Log the error
-          server.log('error', debug); // see: github.com/dwyl/hapi-error/issues/22
+          server.log('error', debug); // github.com/dwyl/hapi-error/issues/22
 
           // Header check, should take priority
           if (accept && accept.match(/json/)) { // support REST/JSON requests
@@ -114,7 +122,8 @@ exports.plugin = {
           if (currentCodeConfig && currentCodeConfig.redirect) {
             // if redirect is function invoke it with the request object
             if (isFunction(currentCodeConfig.redirect)) {
-              return reply.redirect(currentCodeConfig.redirect(request));
+              const url = currentCodeConfig.redirect(request)
+              return reply.redirect(url);
             }
             else {
               // if parameter is string, append redirect query

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 var pkg = require('../package.json'); // require package.json for attributes
 
 function isFunction(functionToCheck) {
@@ -115,8 +115,8 @@ exports.plugin = {
             // if redirect is function invoke it with the request object
             if (isFunction(currentCodeConfig.redirect)) {
               return reply.redirect(currentCodeConfig.redirect(request));
-            } 
-            else { 
+            }
+            else {
               // if parameter is string, append redirect query
               var redirectString = request.url.pathname + request.url.search;
               return reply.redirect(currentCodeConfig.redirect + '?redirect=' + redirectString);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "check-coverage": "npm run test && nyc check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "lint": "node_modules/.bin/goodparts ./lib"
   },
+  "engines": {
+    "node": ">=8.10.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dwyl/hapi-error.git"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/dwyl/hapi-error#readme",
   "dependencies": {
-    "hoek": "^5.0.3"
+    "@hapi/hoek": "^9.0.2"
   },
   "devDependencies": {
     "boom": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
   "devDependencies": {
     "@hapi/boom": "^9.0.0",
     "@hapi/good": "^9.0.0",
-    "boom": "^7.3.0",
     "decache": "^4.5.1",
-    "good-console": "^8.0.0",
-    "good-squeeze": "^5.1.0",
     "handlebars": "^4.7.2",
     "hapi": "^18.1.0",
     "hapi-auth-jwt2": "^8.8.1",

--- a/package.json
+++ b/package.json
@@ -27,23 +27,24 @@
     "@hapi/hoek": "^9.0.2"
   },
   "devDependencies": {
-    "boom": "^7.2.0",
-    "decache": "^4.1.0",
-    "good": "^8.1.1",
-    "good-console": "^7.1.0",
-    "good-squeeze": "^5.0.2",
-    "handlebars": "^4.0.10",
-    "hapi": "^17.2.3",
-    "hapi-auth-jwt2": "^8.1.0",
-    "joi": "^13.4.0",
-    "jsonwebtoken": "^8.3.0",
-    "nodemon": "^1.11.0",
-    "nyc": "12.0.2",
+    "@hapi/boom": "^9.0.0",
+    "boom": "^7.3.0",
+    "decache": "^4.5.1",
+    "good": "^8.1.2",
+    "good-console": "^8.0.0",
+    "good-squeeze": "^5.1.0",
+    "handlebars": "^4.7.2",
+    "hapi": "^18.1.0",
+    "hapi-auth-jwt2": "^8.8.1",
+    "joi": "^14.3.1",
+    "jsonwebtoken": "^8.5.1",
+    "nodemon": "^2.0.2",
+    "nyc": "15.0.0",
     "pre-commit": "^1.2.2",
     "tap-nyc": "1.0.3",
-    "tape": "4.9.1",
+    "tape": "4.13.0",
     "tape-async": "2.3.0",
-    "vision": "^5.3.3"
+    "vision": "^5.4.4"
   },
   "pre-commit": [
     "check-coverage"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "devDependencies": {
     "@hapi/boom": "^9.0.0",
+    "@hapi/good": "^9.0.0",
     "boom": "^7.3.0",
     "decache": "^4.5.1",
-    "good": "^8.1.2",
     "good-console": "^8.0.0",
     "good-squeeze": "^5.1.0",
     "handlebars": "^4.7.2",

--- a/test/api_server.js
+++ b/test/api_server.js
@@ -2,7 +2,7 @@
 
 // this mini server is for: https://github.com/dwyl/hapi-error/issues/49
 var Hapi = require('hapi');
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 
 var server = new Hapi.Server();
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,7 +101,7 @@ test('Initializing message_server_example', async function (t) {
 test('Initializing server_example', async function (t) {
   decache('../example/server.js');
   const server = await require('../example/server_example')();
-  
+
   test("GET / returns 200",async function (t) {
     const options = {
       method: 'GET',
@@ -245,4 +245,3 @@ test('Initializing api_server', async function (t) {
     t.end();
   });
 });
-

--- a/test/jwt_server_example.js
+++ b/test/jwt_server_example.js
@@ -3,7 +3,7 @@
 process.env.JWT_SECRET = 'supersecret'; // github.com/dwyl/hapi-auth-jwt2#generating-your-secret-key
 var Hapi = require('hapi');
 var path = require('path');
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 var assert = require('assert');
 var server = new Hapi.Server({ port: 8765, debug: false });
 

--- a/test/jwt_server_example.js
+++ b/test/jwt_server_example.js
@@ -44,11 +44,11 @@ module.exports = async () => {
       validate: validate
     });
     await server.route([
-      { method: 'GET', path: '/throwerror', config: { auth: 'jwt' }, 
+      { method: 'GET', path: '/throwerror', config: { auth: 'jwt' },
         handler: function throwerror (request, reply) {
           var err = true; // deliberately throw an error for https://git.io/vPZ4A
           return request.handleError(err, { errorMessage: 'Sorry, we haz fail.'});
-        } 
+        }
     }]);
     Hoek.assert('no errors registering plugins');
     return server;

--- a/test/message_server_example.js
+++ b/test/message_server_example.js
@@ -3,7 +3,7 @@
 require('decache')('../example/server.js');
 // ensure we have a fresh module
 var server = require('../example/server.js');
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 var Path = require('path');
 var Handlebars = require('handlebars');
 

--- a/test/redirect_server_example.js
+++ b/test/redirect_server_example.js
@@ -10,7 +10,8 @@ var config = {
   },
   "403": {
     "redirect": function (request) {
-      return "/login?redirect=" + request.url.path
+      var redirectString = request.url.pathname + request.url.search;
+      return "/login?redirect=" + redirectString
     }
   }
 };

--- a/test/redirect_server_example.js
+++ b/test/redirect_server_example.js
@@ -2,7 +2,7 @@
 
 require('decache')('../example/server.js'); // ensure we have a fresh module
 var server = require('../example/server.js');
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 
 var config = {
   "401": { // if the statusCode is 401 redirect to /login page/endpoint

--- a/test/uncaught_exception_server.js
+++ b/test/uncaught_exception_server.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Hapi = require('hapi');
-var Hoek = require('hoek');
+var Hoek = require('@hapi/hoek');
 
 var server = new Hapi.Server();
 

--- a/test/uncaught_exception_server.js
+++ b/test/uncaught_exception_server.js
@@ -8,7 +8,7 @@ var server = new Hapi.Server();
 module.exports = async () => {
   try {
     await server.register({
-      plugin: require('good'),
+      plugin: require('@hapi/good'),
       options: require('./good_options'),
     });
     await server.register(require('../lib/index.js'));


### PR DESCRIPTION
This is a _maintenance_ PR, it _should_ preserve backward compatibility with `v2.2.2`.
I just don't like seeing 🔴 badges in projects ... #73 

What's included? 
+ [x] Updates the _main_ dependency `hoek` to `@hapi/hoek` (_Hapi's new namespacing convention..._) 🙄 
+ [x] Updates all `devDependencies` to latest versions 
  + [x] including migrating the ones that _work_ without modification to the `@hapi/{module}` namespace.
+ [x] Update badges to `flat-square` for consistency with our other projects.

@iteles please review/merge when you can. Thanks! ✨ 